### PR TITLE
Clear screen between builds and improve output display

### DIFF
--- a/pkg/cmd/dev.go
+++ b/pkg/cmd/dev.go
@@ -387,6 +387,12 @@ func runPreview(ctx context.Context, cmd *cli.Command) error {
 		if !cmd.Bool("watch") {
 			break
 		}
+
+		// Clear the screen and move the cursor to the top
+		fmt.Print("\nRebuilding...\n\n\033[2J\033[H")
+		os.Stdout.Sync()
+		Property("branch", selectedBranch)
+		Property("targets", strings.Join(selectedTargets, ", "))
 	}
 	return nil
 }

--- a/pkg/cmd/dev_view.go
+++ b/pkg/cmd/dev_view.go
@@ -105,10 +105,10 @@ var parts = []struct {
 		},
 	},
 	{
-		name: "diagnostics",
+		name: "build diagnostics",
 		view: func(m BuildModel, s *strings.Builder) {
 			if m.diagnostics == nil {
-				s.WriteString(SProperty(0, "diagnostics", "waiting for build to finish"))
+				s.WriteString(SProperty(0, "build diagnostics", "(waiting for build to finish)"))
 			} else {
 				s.WriteString(ViewDiagnosticsPrint(m.diagnostics, 10))
 			}
@@ -362,7 +362,7 @@ func ViewDiagnosticsPrint(diagnostics []stainless.BuildDiagnostic, maxDiagnostic
 			}
 		}
 
-		s.WriteString(SProperty(0, "diagnostics", summary))
+		s.WriteString(SProperty(0, "build diagnostics", summary))
 		s.WriteString(lipgloss.NewStyle().
 			Padding(0).
 			Border(lipgloss.RoundedBorder()).
@@ -370,7 +370,7 @@ func ViewDiagnosticsPrint(diagnostics []stainless.BuildDiagnostic, maxDiagnostic
 			Render(strings.TrimRight(sub.String(), "\n")),
 		)
 	} else {
-		s.WriteString(SProperty(0, "diagnostics", "(no errors or warnings)"))
+		s.WriteString(SProperty(0, "build diagnostics", "(no errors or warnings)"))
 	}
 
 	return s.String()

--- a/pkg/cmd/lint.go
+++ b/pkg/cmd/lint.go
@@ -56,6 +56,7 @@ type lintModel struct {
 	diagnostics []stainless.BuildDiagnostic
 	error       error
 	watching    bool
+	skipped     bool
 	canSkip     bool
 	ctx         context.Context
 	cmd         *cli.Command
@@ -77,6 +78,7 @@ func (m lintModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		} else if msg.String() == "enter" {
 			m.watching = false
+			m.skipped = true
 			return m, tea.Quit
 		}
 
@@ -124,10 +126,16 @@ func (m lintModel) View() string {
 	if m.error != nil {
 		content = "Linting failed!"
 	} else if m.diagnostics == nil {
-		content = m.spinner.View() + " Linting"
+		if m.skipped {
+			content = "Skipped!"
+		} else {
+			content = m.spinner.View() + " Linting"
+		}
 	} else {
 		content = ViewDiagnosticsPrint(m.diagnostics, -1)
-		if m.watching {
+		if m.skipped {
+			content += "\nContinuing..."
+		} else if m.watching {
 			content += "\n" + m.spinner.View() + " Waiting for configuration changes"
 		}
 	}


### PR DESCRIPTION
When running `stl preview --watch`, clear the screen after each build so we don't see the old build logs anymore (but they still remain in the history). Also, change to `build diagnostics` to distinguish between the linter diagnostics run before the build vs. those that came back from the build server. Finally, if the user does hit 'enter' to skip the diagnostics, show that information in the display instead of leaving an interrupted progress spinner.