### PR TITLE
Ensure stdout respects format flag

### DIFF
--- a/cmd/stl/main.go
+++ b/cmd/stl/main.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/stainless-api/stainless-api-cli/pkg/cmd"
@@ -19,7 +18,6 @@ func main() {
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		var apierr *stainless.Error
 		if errors.As(err, &apierr) {
-			fmt.Fprintf(os.Stderr, "%s %q: %d %s\n", apierr.Request.Method, apierr.Request.URL, apierr.Response.StatusCode, http.StatusText(apierr.Response.StatusCode))
 			format := app.String("format-error")
 			json := gjson.Parse(apierr.RawJSON())
 			show_err := cmd.ShowJSON("Error", json, format, app.String("transform-error"))

--- a/pkg/cmd/buildtargetoutput.go
+++ b/pkg/cmd/buildtargetoutput.go
@@ -98,9 +98,17 @@ func handleBuildsTargetOutputsRetrieve(ctx context.Context, cmd *cli.Command) er
 		return err
 	}
 
-	group := Info("Downloading output")
+	// Whether or not to print information about each step as it happens
+	showInfo := !cmd.IsSet("format") || cmd.String("format") == "auto" || cmd.String("format") == "pretty"
+
+	var group *Group
+	if showInfo {
+		g := Info("Downloading output")
+		group = &g
+	}
+
 	if cmd.Bool("pull") {
-		return pullOutput(res.Output, res.URL, res.Ref, "", &group)
+		return pullOutput(res.Output, res.URL, res.Ref, "", group)
 	}
 
 	return nil


### PR DESCRIPTION
Ensure that we're not outputting text to stdout that isn't in the specified format if the user does specify a format. For example `stl builds create --format=json` should only output JSON.