### PR TITLE
Nonzero exit status on build failure

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -523,6 +523,7 @@ func handleBuildsCreate(ctx context.Context, cmd *cli.Command) error {
 			target.Get("commit.completed.conclusion").String() == "error" ||
 			target.Get("lint.completed.conclusion").String() == "error" ||
 			target.Get("test.completed.conclusion").String() == "error" {
+			buildGroup.Error("Build did not succeed!")
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
Ensure that `stl builds create` gives a nonzero exit status when builds fail.